### PR TITLE
require 'scout_apm' before using ScoutApm constant

### DIFF
--- a/lib/scout_dogstatsd.rb
+++ b/lib/scout_dogstatsd.rb
@@ -1,3 +1,5 @@
+require 'scout_apm'
+
 module ScoutDogstatsd
   # All access to the agent is thru this class method to ensure multiple Agent instances are not initialized per-Ruby process.
   def self.configure(dogstatsd_client)


### PR DESCRIPTION
Without this, the instructions in the README fail with a NameError. It may have to do with not using scout directly, but I can't be positive.