### PR TITLE
Update Gemspec to support `scout_apm >= 2.4.11.pre`; newer `bundler`

### DIFF
--- a/scout_dogstatsd.gemspec
+++ b/scout_dogstatsd.gemspec
@@ -18,11 +18,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.11"
+  spec.add_development_dependency "bundler", ">= 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "mocha"
 
-  spec.add_runtime_dependency "scout_apm", "~> 2.4.11.pre"
+  spec.add_runtime_dependency "scout_apm", ">= 2.4.11.pre"
   spec.add_runtime_dependency "dogstatsd-ruby"
 end


### PR DESCRIPTION
* `scout_apm` has been updated to `2.5.1`; updating the version this gem
	depends on allows users to upgrade

This closes #3 